### PR TITLE
use UnDEAD XML dependency since std.xml got removed from phobos, add …

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,10 +1,28 @@
 {
-    "name": "qrcode",
-    "description": "QRCode writen in D programming lanuage.",
-    "copyright": "Copyright (C) 2015-2016 Shanghai Putao Technology Co., Ltd",
-    "authors": [ "donglei" ],
-    "license": "Apache-2.0",
-    "dependencies": {
-        "dmagick": "~>0.2.1"
-    }
+	"authors": [
+		"donglei"
+	],
+	"configurations": [
+		{
+			"dependencies": {
+				"dmagick": "~>0.2.1"
+			},
+			"name": "default",
+			"targetType": "library"
+		},
+		{
+			"excludedSourceFiles": [
+				"source/qrcode/renderer/image/png.d"
+			],
+			"name": "nopng",
+			"targetType": "library"
+		}
+	],
+	"copyright": "Copyright (C) 2015-2016 Shanghai Putao Technology Co., Ltd",
+	"dependencies": {
+		"undead": "~>1.1.8"
+	},
+	"description": "QRCode writen in D programming lanuage.",
+	"license": "Apache-2.0",
+	"name": "qrcode"
 }

--- a/source/qrcode/package.d
+++ b/source/qrcode/package.d
@@ -32,6 +32,9 @@ public import qrcode.renderer.text.plain;
 public import qrcode.renderer.image.abstractrender;
 public import qrcode.renderer.image.svg;
 public import qrcode.renderer.image.eps;
-public import qrcode.renderer.image.png;
+
+version(Have_dmagick){
+    public import qrcode.renderer.image.png;
+}
 public import qrcode.renderer.image.decorator.decoratorinterface;
 public import qrcode.renderer.image.decorator.finderpattern;

--- a/source/qrcode/renderer/image/svg.d
+++ b/source/qrcode/renderer/image/svg.d
@@ -4,7 +4,8 @@ import qrcode.renderer.image.abstractrender;
 import qrcode.renderer.color.colorinterface;
 
 
-import std.xml,std.conv, std.format;
+import std.conv, std.format;
+import undead.xml;
 /**
 * SVG backend.
 */
@@ -100,7 +101,6 @@ class Svg : AbstractRenderer
 		use.tag.attr["xlink:href"] = this.getRectPrototypeId(colorId);
 		use.tag.attr["xmlns:xmi"] = "http://www.w3.org/1999/xlink";
 
-      
 		this.svg ~= use;
     }
     /**


### PR DESCRIPTION
…noPNG configuration to elminate dmagick dependency if not desired

I used `dub add` to add the undead dependency and it reformatted the dub.json file.  I can try to make a more minimal diff if you want.  I could also split this into 2 PRs if you think that's helpful, but it seems like this isn't that actively developed and the diff is pretty small.